### PR TITLE
Apply edits, README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,35 @@
 
 Stylometry is the application of the study of linguistic style, usually to written language, but it has successfully been applied to music and to fine-art paintings as well.
 
-Stylometry is often used to attribute authorship to anonymous or disputed documents. It has legal as well as academic and literary applications, ranging from the question of the authorship of Shakespeare's works to forensic linguistics.
+Stylometry is often used to attribute authorship to anonymous or disputed documents. Stylometry has legal, academic, and literary applications, which include determination of the true authorship of some of Shakespeare's works and forensic linguistics.
 
 ## Why write a library?
 
-After searching through a wide variety of libraries for Python I was unable to find one that seemed to fit the needs. 
+Even after hours of searching through Python libraries, I was unable to find one that seemed to fit my needs.
 
-I also found a research paper that I really like that talked about applying machine learning techniques and stylometry. I decided to write a simple library while learning more about the NLTK python library. 
+But soon, I found a captivating research paper that talked about applying machine learning techniques to stylometry. In addition, I stumbled upon an awesome library that provied the foundation for statistical analysis of raw text data: the Natural Language Tooklit Library, or NLTK. Based on this foundation, I decided to write a simple library that could specifically handle stylometry.
 
-The initial version of the software took only about 3 hours and allowed me to extract a wide variety of features from text data. The library has since been extended into several different facets
+The initial version of the software took only about 3 hours in development and still allowed me to extract a wide variety of features from text data. The library has since been extended into several different facets.
 
-## Setting Up
+## How to set up the software
 
-1. System Dependendencies (Mac Specific)
+1. Mac users must set up some special system dependencies:
 
 ```bash
 brew install graphviz
 ```
 
-1. install necessary packages from requirements.txt: 
+1. Install necessary packages from requirements.txt:
 ```bash
 pip install -r requirements.txt
 ```
-2. install nltk punkt tokenizer: 
+2. Additionally, install `nltk`, `punkt`, and `tokenizer`: 
 ```python
 import nltk
 nltk.download('punkt')
 ```
 
-3. If you get this error ``Couldn't import dot_parser, loading of dot files will not be possible.``
+3. If you get this error, ``Couldn't import dot_parser, loading of dot files will not be possible.``, do this:
 
 ```bash
 pip uninstall pydot
@@ -39,14 +39,14 @@ pip install -Iv https://pypi.python.org/packages/source/p/pyparsing/pyparsing-1.
 pip install pydot
 ```
 
-## Data Preparation
+## How to prepare text data
 
-1. Download Text from Gutenberg Project
-2. Clean up Text files removing table of contents, licenses, etc
-3. Split the file into 1000 line samples using ``split -l 1000 hamlet.txt -d`` to rename the output files consider using ``split --numeric-suffixes=1 --additional-suffix=.csv -l 1000 hamlet.txt hamlet_``
-4. To rebuild the original data just ``cat book-0.txt book-1.txt book-2.txt > entire-book.txt``
+1. Download some text from Gutenberg Project.
+2. Clean up the text files by removing table of contents, licenses, etc.
+3. Split the file into 1000 line samples using ``split -l 1000 hamlet.txt -d``. To rename the output files, consider using ``split --numeric-suffixes=1 --additional-suffix=.csv -l 1000 hamlet.txt hamlet_``.
+4. After preparation, you may rebuild the original data using this command: ``cat book-0.txt book-1.txt book-2.txt > entire-book.txt``.
 
-I tried to make sure that every author have a similar number of lines and samples to analyze.
+Make sure that every author have a similar number of lines and samples to analyze. For example,
 
 | Title | Author | Lines | Samples |
 --- | --- | --- | ---


### PR DESCRIPTION
Applied some grammatical, stylistic, and rhetorical edits to your README.txt.

Some -- but not all -- of the edits are disclosed here:

1. "It" ---> "stylometry". Rationale: keywords are special words that are repeated over and over in a paragraph. They cast a focus to the main topic of the paragraph, so replacing them with pronouns confuse the reader.

2. "... legal as well as ..." ---> "legal". Rationale: excessively verbose

3. "... ranging from the ..." ---> "including the". Rationale: to highlight the fact that those are not ALL the possible the uses of stylometry, but some prominent or interesting examples.

4. "... wide variety of libraries for Python ..." ---> revised sentence structure to effectively introduce the sentence.

5. "I also found a ..." ---> revised paragraph. The original paragraph had a number of issues, including but not limited to, a grammatical error, some stylistic and logical cohesion mistakes, and most importantly not effectively conveying the main idea.

6. Headers. I chose to reword the headings to match the style of the whole text.

7. Rewording some steps. There were little issues regarding grammar and style.